### PR TITLE
Fix a clean install Yosemite issue with brew cask

### DIFF
--- a/bootstrap-new-system.sh
+++ b/bootstrap-new-system.sh
@@ -40,7 +40,7 @@ if [[ `uname` == 'Darwin' ]]; then
   # http://github.com/sindresorhus/quick-look-plugins
   echo 'Installing Quick Look plugins...'
     brew tap phinze/homebrew-cask
-    brew install brew-cask
+    brew install caskroom/cask/brew-cask
     brew cask install suspicious-package quicklook-json qlmarkdown qlstephen qlcolorcode
 fi
 


### PR DESCRIPTION
Cask is not recognised correctly on clean Yosemite installs. This is due to a weird compounding error as discussed in [homebrew/4667](https://github.com/caskroom/homebrew-cask/issues/4667)